### PR TITLE
Return jqXHR object, fixes #2

### DIFF
--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -375,6 +375,7 @@ TDI.Ajax.Request = function($) {
 		 * <p>Sends the Ajax request and calls the needed callback methods.</p>
 		 * @method send
 		 * @static
+		 * @return {jqXHR} xhr The jqXHR object
 		 * @param {String} url The request URL.
 		 * @param {Object} options Aditional request options:
 		 *   <dl>
@@ -426,7 +427,7 @@ TDI.Ajax.Request = function($) {
 			options.async = !options.sync;
 			options.data = options.data || '';
 
-			$.ajax( {
+			return $.ajax( {
 				url			: options.url,
 				xhrFields   : options.xhrFields,
 				type		: options.method,


### PR DESCRIPTION
I'm not sure if the return of jqXHR should bubble in the API, the `TDI.Ajax.Request.send` method is used in:

 * `TDI.Ajax.Request.sendForm`
 * `TDI.Ajax.send`

and possible other places.
