### PR TITLE
Use jquery loader for tests WIP

### DIFF
--- a/tests/jquery/jquery_loader.js
+++ b/tests/jquery/jquery_loader.js
@@ -1,0 +1,11 @@
+(function (){
+  // Default to the local version.
+  var path = 'http://code.jquery.com/jquery-1.10.2.min.js';
+  // Get any jquery=___ param from the query string.
+  var jqversion = location.search.match(/[?&]jquery=(.*?)(?=&|$)/);
+  // If a version was specified, use that version from code.jquery.com.
+  if (jqversion) {
+    path = 'http://code.jquery.com/jquery-' + jqversion[1] + '.min.js';
+  }
+  document.write('<script src="' + path + '"></script>');
+}());

--- a/tests/tdi-ajax-request-forms-old.html
+++ b/tests/tdi-ajax-request-forms-old.html
@@ -27,7 +27,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script>
 		window.FormData = undefined;
 	</script>

--- a/tests/tdi-ajax-request-forms.html
+++ b/tests/tdi-ajax-request-forms.html
@@ -27,7 +27,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.js"></script>
 
 	<script src="tdi-ajax-request-forms-tests.js"></script>

--- a/tests/tdi-ajax-request.html
+++ b/tests/tdi-ajax-request.html
@@ -27,7 +27,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.js"></script>
 
 	<script src="tdi-ajax-request-tests.js"></script>

--- a/tests/tdi-ajax-response-error.html
+++ b/tests/tdi-ajax-response-error.html
@@ -9,7 +9,7 @@
 	<div id="qunit-fixture"></div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-ajax-response-error-tests.js"></script>

--- a/tests/tdi-ajax-response-events-prevent.html
+++ b/tests/tdi-ajax-response-events-prevent.html
@@ -26,7 +26,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-ajax-response-events-prevent-tests.js"></script>

--- a/tests/tdi-ajax-response-events.html
+++ b/tests/tdi-ajax-response-events.html
@@ -28,7 +28,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-ajax-response-events-tests.js"></script>

--- a/tests/tdi-ajax-response-responses.html
+++ b/tests/tdi-ajax-response-responses.html
@@ -40,7 +40,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-ajax-response-responses-tests.js"></script>

--- a/tests/tdi-ajax-ui.html
+++ b/tests/tdi-ajax-ui.html
@@ -48,7 +48,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-ajax-ui-tests.js"></script>

--- a/tests/tdi-ajax.html
+++ b/tests/tdi-ajax.html
@@ -31,7 +31,7 @@
 	</div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-ajax-tests.js"></script>

--- a/tests/tdi-tools.html
+++ b/tests/tdi-tools.html
@@ -9,7 +9,7 @@
 	<div id="qunit-fixture"></div>
 
 	<script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+	<script src="jquery/jquery_loader.js"></script>
 	<script src="../build/tdi-bundle.min.js"></script>
 
 	<script src="tdi-tools-tests.js"></script>


### PR DESCRIPTION
This is WIP for testing against more versions of JQuery.

I'm not familiar with gulp pipe system so the gulpfile is untouched.

The idea is to pass ?jquery=3.1.1 to the unit test html when running qunit.
The `jquery_loader.js` will than simply load corresponding version from code.jquery.com.

Can something like this be accomplished with grunt pipe system?

    var jQueryVersions = ['1.10.2', '1.11.1', '2.1.3', '3.1.1'];
    var getUnitTestUrls = function (baseFiles, jQueryVersions) {
      var urls = [];
      for (var i = 0, count = baseFiles.length; i < count; i++) {
        var file = baseFiles[i];
        for (var v = 0; v < jQueryVersions.length; v++) {
          urls.push(file + '?jquery=' + jQueryVersions[v]);
        }
      }
      return urls;
    };

    getUnitTestUrls(testGlob, jQueryVersions).pipe(qunit) ?



