### PR TITLE
Xml tag, fixes #12

### DIFF
--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -1287,7 +1287,8 @@ TDI.Ajax.Response = function($) {
 				attributes = tag.attributes,
 				event_data = {
 					_name : name,
-					contents : $.trim( $tag.text() )
+					contents : $.trim( $tag.text() ),
+					tag : $tag,
 				};
 
 			for (var i = 0, l = attributes.length; i < l; i++) {
@@ -1306,6 +1307,8 @@ TDI.Ajax.Response = function($) {
 				 *       <span>Instruction contents</dd>
 				 *     <dd><code><span>ATTRS_NAME</span> <span>&lt;String&gt;</span></code>
 				 *       <span>Other attributes</dd>
+				 *     <dd><code><span>tag</span> <span>&lt;jQuery&gt;</span></code>
+				 *       <span>The XML tag</span></dd>
 				 *   </dl>
 				 */
 				$.event.special[ 'tdi:ajax:before' + beforeName ] = {

--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -1096,7 +1096,8 @@ TDI.Ajax.Response = function($) {
 					script_src	: src,
 					script_data	: contents,
 					script_id	: id,
-					options		: options
+					options		: options,
+					tag				: $tag,
 				};
 
 			// fire custom events
@@ -1113,6 +1114,8 @@ TDI.Ajax.Response = function($) {
 				 *       <span>Inline Javascript code</span></dd>
 				 *     <dd><code><span>script_id</span> <span>&lt;String&gt;</span></code>
 				 *       <span>ID of the &lt;script&gt; tag</span></dd>
+				 *     <dd><code><span>tag</span> <span>&lt;jQuery&gt;</span></code>
+				 *       <span>The XML tag</span></dd>
 				 *   </dl>
 				 */
 				$(document).trigger( 'tdi:ajax:beforeScript', event_data );

--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -1239,7 +1239,8 @@ TDI.Ajax.Response = function($) {
 					mode	: mode,
 					width	: parseInt(width),
 					height	: parseInt(height),
-					options	: options
+					options	: options,
+					tag			: $tag,
 				};
 
 			if ( href ) {
@@ -1259,6 +1260,8 @@ TDI.Ajax.Response = function($) {
 					 *       <span>Width of the popup. Available only for <em>dialog</em> mode</span></dd>
 					 *     <dd><code><span>height</span> <span>&lt;Integer&gt;</span></code>
 					 *       <span>Height of the popup. Available only for <em>dialog</em> mode</span></dd>
+					 *     <dd><code><span>tag</span> <span>&lt;jQuery&gt;</span></code>
+					 *       <span>The XML tag</span></dd>
 					 *   </dl>
 					 */
 					$(document).trigger( 'tdi:ajax:beforePopup', event_data );

--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -1045,7 +1045,8 @@ TDI.Ajax.Response = function($) {
 					content			: content,
 					position		: position,
 					inserted_node	: inserted_node,
-					options			: options
+					options			: options,
+          tag					: $tag,
 				};
 
 			if ( target.length > 0 ) {
@@ -1065,6 +1066,8 @@ TDI.Ajax.Response = function($) {
 					 *       <span>The contents</span></dd>
 					 *     <dd><code><span>position</span> <span>&lt;String&gt;</span></code>
 					 *       <span>The position of the insert (before|after)</span></dd>
+					 *     <dd><code><span>tag</span> <span>&lt;jQuery&gt;</span></code>
+					 *       <span>The XML tag</span></dd>
 					 *   </dl>
 					 */
 					target.first().trigger( 'tdi:ajax:beforeInsert', event_data );

--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -976,7 +976,8 @@ TDI.Ajax.Response = function($) {
 					prepend			: prepend,
 					class_add		: class_add,
 					class_remove	: class_remove,
-					options			: options
+					options			: options,
+					tag					: $tag,
 				};
 
 			if ( target.length > 0 ) {
@@ -1008,6 +1009,8 @@ TDI.Ajax.Response = function($) {
 					 *       <span>Space separated list of class names to add</span></dd>
 					 *     <dd><code><span>class_remove</span> <span>&lt;String&gt;</span></code>
 					 *       <span>Space separates list of class names to remove</span></dd>
+					 *     <dd><code><span>tag</span> <span>&lt;jQuery&gt;</span></code>
+					 *       <span>The XML tag</span></dd>
 					 *   </dl>
 					 */
 					target.first().trigger( 'tdi:ajax:beforeUpdate', event_data );

--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -1141,7 +1141,8 @@ TDI.Ajax.Response = function($) {
 				event_data = {
 					style_src	: src,
 					style_id	: id,
-					options		: options
+					options		: options,
+					tag				: $tag,
 				};
 
 			// fire custom events
@@ -1156,6 +1157,8 @@ TDI.Ajax.Response = function($) {
 				 *       <span>Path to the external CSS file</span></dd>
 				 *     <dd><code><span>style_id</span> <span>&lt;String&gt;</span></code>
 				 *       <span>ID of the &lt;link&gt; tag</span></dd>
+				 *     <dd><code><span>tag</span> <span>&lt;jQuery&gt;</span></code>
+				 *       <span>The XML tag</span></dd>
 				 *   </dl>
 				 */
 				$(document).trigger( 'tdi:ajax:beforeStyle', event_data );

--- a/tests/tdi-ajax-response-responses-tests.js
+++ b/tests/tdi-ajax-response-responses-tests.js
@@ -2,7 +2,7 @@ QUnit.module( 'TDI.Ajax.Response' );
 
 QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 	var done = assert.async();
-	assert.expect(182);
+	assert.expect(183);
 
 	// bind the events
 	$(document)
@@ -234,6 +234,8 @@ QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 
 			// check the markup
 			assert.equal( $( '#style1' ).length, 1, 'Style loaded.' );
+
+			assert.ok(data.styles[0].tag instanceof $);
 		} )
 		.bind( 'tdi:ajax:popupsDone', function( evt, data ) {
 			// 3 popups are expected

--- a/tests/tdi-ajax-response-responses-tests.js
+++ b/tests/tdi-ajax-response-responses-tests.js
@@ -2,7 +2,7 @@ QUnit.module( 'TDI.Ajax.Response' );
 
 QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 	var done = assert.async();
-	assert.expect(179);
+	assert.expect(182);
 
 	// bind the events
 	$(document)
@@ -221,6 +221,11 @@ QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 				assert.ok( s3.script_node, "Script 3 tag exists" );
 				assert.ok( s3.script_node_inline, "Script 3 inline tag exists" );
 			}, 200);
+
+			assert.ok(s1.tag instanceof $);
+			assert.ok(s2.tag instanceof $);
+			assert.ok(s3.tag instanceof $);
+
 		} )
 		.bind( 'tdi:ajax:stylesDone', function( evt, data ) {
 			// check the API data (expect 1 style)

--- a/tests/tdi-ajax-response-responses-tests.js
+++ b/tests/tdi-ajax-response-responses-tests.js
@@ -2,7 +2,7 @@ QUnit.module( 'TDI.Ajax.Response' );
 
 QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 	var done = assert.async();
-	assert.expect(183);
+	assert.expect(186);
 
 	// bind the events
 	$(document)
@@ -250,6 +250,10 @@ QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 			assert.equal( p3.href, 'responses/popup3.html', 'Dialog: correct URL' );
 			assert.equal( p3.width, 300, 'Dialog: correct width' );
 			assert.equal( p3.height, 300, 'Dialog: correct height' );
+
+			assert.ok(p1.tag instanceof $);
+			assert.ok(p2.tag instanceof $);
+			assert.ok(p3.tag instanceof $);
 
 			p1.popup.close();
 			p2.popup.close();

--- a/tests/tdi-ajax-response-responses-tests.js
+++ b/tests/tdi-ajax-response-responses-tests.js
@@ -2,7 +2,7 @@ QUnit.module( 'TDI.Ajax.Response' );
 
 QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 	var done = assert.async();
-	assert.expect(173);
+	assert.expect(179);
 
 	// bind the events
 	$(document)
@@ -159,6 +159,13 @@ QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 			assert.equal( i6.content, '<div class="inserted-multiple-before">Inserted before</div>', 'Insert6: content' );
 			assert.equal( i6.position, 'before', 'Insert6: position' );
 			assert.equal( i6.inserted_node.length, 2, 'Insert6: inserted nodes' );
+
+			assert.ok(i1.tag instanceof $);
+			assert.ok(i2.tag instanceof $);
+			assert.ok(i3.tag instanceof $);
+			assert.ok(i4.tag instanceof $);
+			assert.ok(i5.tag instanceof $);
+			assert.ok(i6.tag instanceof $);
 
 			// check the markup
 			assert.equal( $( '#inserted-after-default' ).length, 1, 'Inserted after (default)' );

--- a/tests/tdi-ajax-response-responses-tests.js
+++ b/tests/tdi-ajax-response-responses-tests.js
@@ -2,7 +2,7 @@ QUnit.module( 'TDI.Ajax.Response' );
 
 QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 	var done = assert.async();
-	assert.expect(186);
+	assert.expect(191);
 
 	// bind the events
 	$(document)
@@ -289,6 +289,12 @@ QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 			assert.equal( u5._name, 'dialog', 'Dialog: correct instruction name' );
 			assert.equal( u5.action, 'close', 'Dialog: correct action' );
 			assert.equal( u5.id, 'dialog3', 'Dialog: correct id' );
+
+			assert.ok(u1.tag instanceof $);
+			assert.ok(u2.tag instanceof $);
+			assert.ok(u3.tag instanceof $);
+			assert.ok(u4.tag instanceof $);
+			assert.ok(u5.tag instanceof $);
 		} )
 		.bind( 'tdi:ajax:done', function( evt, data ) {
 			var r = data.responses;

--- a/tests/tdi-ajax-response-responses-tests.js
+++ b/tests/tdi-ajax-response-responses-tests.js
@@ -2,7 +2,7 @@ QUnit.module( 'TDI.Ajax.Response' );
 
 QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 	var done = assert.async();
-	assert.expect(163);
+	assert.expect(173);
 
 	// bind the events
 	$(document)
@@ -72,6 +72,17 @@ QUnit.test( 'TDI.Ajax.Response: events and XML', function( assert ) {
 			assert.equal( u10.selector, '.update-multiple-prepend', 'Update10: selector' );
 			assert.equal( u10.target.length, 2, 'Update10: targets' );
 			assert.equal( u10.content, 'Update prepend' );
+
+			assert.ok(u1.tag instanceof $);
+			assert.ok(u2.tag instanceof $);
+			assert.ok(u3.tag instanceof $);
+			assert.ok(u4.tag instanceof $);
+			assert.ok(u5.tag instanceof $);
+			assert.ok(u6.tag instanceof $);
+			assert.ok(u7.tag instanceof $);
+			assert.ok(u8.tag instanceof $);
+			assert.ok(u9.tag instanceof $);
+			assert.ok(u10.tag instanceof $);
 
 			// check the markup
 			assert.equal( $( '#update-default' ).text(), 'Update default', 'The target was updated and has the correct contents.' );


### PR DESCRIPTION
This PR adds xml tag to the event data object.

I had some troubles following the coding style the source uses. Hopefully I got it right.

I came across minor problems with documentation of the events (Its missing other parameters) - This can be  part of another PR.