### PR TITLE
Allow callbacks to be passed in by the default handlers

### DIFF
--- a/src/js/tdi-ajax.js
+++ b/src/js/tdi-ajax.js
@@ -158,7 +158,7 @@
 		 * @param {Event} evt The event object
 		 */
 		function _onLinkClick(evt) {
-			TDI.Ajax.send(evt.target);
+			TDI.Ajax.send(evt.target, evt.callbacks);
 		}
 
 		/**
@@ -194,7 +194,7 @@
 		 * @param {Event} evt The event object
 		 */
 		function _onFormSubmit(evt) {
-			TDI.Ajax.send(evt.target);
+			TDI.Ajax.send(evt.target, evt.callbacks);
 		}
 
 		/**


### PR DESCRIPTION
I have to setup custom http header before sending ajax requests. This can be simply implemented by:

    $(document).on('tdi:ajax:beforeLinkClick', 'a',  function(e) {
        e.callbacks = e.callbacks || {};
        e.callbacks.beforeStart = function(xhr, settings, ajaxOptions) {
            xhr.setRequestHeader('X-Foobar', 'yes');
            return true; // make the request
        };
    });

I did not included any test for this - checked the tests sources but could not find suitable place.